### PR TITLE
added template path in compile result

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function compile(id, str) {
   var tokens = JSON.stringify(template.tokens);
 
   // the id will be the filename and path relative to the require()ing module
-  return 'twig({ id: __filename, path: __dirname,  data:' + tokens + ', precompiled: true, allowInlineIncludes: true })';
+  return 'twig({ id: __filename, path: __dirname, data:' + tokens + ', precompiled: true, allowInlineIncludes: true })';
 }
 
 function process(source) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function compile(id, str) {
   var tokens = JSON.stringify(template.tokens);
 
   // the id will be the filename and path relative to the require()ing module
-  return 'twig({ id: __filename,  data:' + tokens + ', precompiled: true, allowInlineIncludes: true })';
+  return 'twig({ id: __filename, path: __dirname,  data:' + tokens + ', precompiled: true, allowInlineIncludes: true })';
 }
 
 function process(source) {


### PR DESCRIPTION
Twig.Template.prototype.importFile uses current template's path to include sub-templates.
There was a bug when loading a sub-template while not in a browser context.
